### PR TITLE
Disabled the sleep time

### DIFF
--- a/capture.py
+++ b/capture.py
@@ -99,4 +99,4 @@ while True:
                 print("Image Created:"+str(int(time.time()))+'.jpeg')
         else:
             print("Please Insert USB Flash Drive")
-    sleep(1)
+    #sleep(1) # we dont need


### PR DESCRIPTION
Image Capture and GPS tagging are slower than expected that's why we don't need sleep.